### PR TITLE
Respond to TCP or UDP traceroutes

### DIFF
--- a/ipv6-traceroute-faker.py
+++ b/ipv6-traceroute-faker.py
@@ -53,6 +53,7 @@ import asyncore
 from nfqueue import queue, NFQNL_COPY_PACKET
 from socket import AF_INET6
 from scapy.all import IPv6, TCP, UDP, ICMPv6TimeExceeded, ICMPv6EchoReply, ICMPv6EchoRequest, ICMPv6DestUnreach, send
+import time
 
 
 def do_callback(payload):
@@ -96,7 +97,7 @@ def do_callback(payload):
                 elif icmp == None and response != None:
                     send(reply/response, verbose=0)
             except UnboundLocalError:
-                print('meh')
+                print(time.ctime() + ': UnboundLocalError')
                 pass
 
 
@@ -111,7 +112,7 @@ class AsyncNfQueue(asyncore.file_dispatcher):
         self._q.set_mode(NFQNL_COPY_PACKET)
 
     def handle_read(self):
-        print('Processing at most 50 events')
+        print(time.ctime() + ': Processing at most 50 events')
         self._q.process_pending(50)
 
     def writable(self):

--- a/ipv6-traceroute-faker.py
+++ b/ipv6-traceroute-faker.py
@@ -68,29 +68,20 @@ def do_callback(payload):
             icmp = None
             response = None
             if hl < path_length:
-                icmp = ICMPv6TimeExceeded()
-                icmp.code = 0
+                icmp = ICMPv6TimeExceeded(code=0)
                 reply.src = "%s%s" % (prefix, hl)
             else:
                 # Packet with hlim >= path_length received. 'Destination' reached.
                 reply.src = destination
                 if isinstance(pkt[1], ICMPv6EchoRequest):
                     # Reply to the ping
-                    response = ICMPv6EchoReply()
-                    response.id = pkt[1].id
-                    response.seq = pkt[1].seq
-                    response.data = pkt[1].data
+                    response = ICMPv6EchoReply(id=pkt[1].id, seq=pkt[1].seq, data=pkt[1].data)
                 if isinstance(pkt[1], TCP) and pkt[1].flags == 'S':
                     # Reject the TCP SYN
-                    response = TCP()
-                    response.sport = pkt[1].dport
-                    response.dport = pkt[1].sport
-                    response.seq = pkt[1].seq
-                    response.flags = 'R'
+                    response = TCP(sport=pkt[1].dport, dport=pkt[1].sport, seq=pkt[1].seq, flags='R')
                 if isinstance(pkt[1], UDP):
                     # Reject the UDP pkt with ICMPv6 port unreachable
-                    icmp = ICMPv6DestUnreach()
-                    icmp.code = 4
+                    icmp = ICMPv6DestUnreach(code=4)
             try:
                 if icmp != None and response == None:
                     send(reply/icmp/pkt, verbose=0)


### PR DESCRIPTION
Respond to TCP or UDP traceroutes, and also return the correct responses to make a trace terminate when it reaches the 'end'.